### PR TITLE
Update greeter-osm.conf

### DIFF
--- a/greeter-osm.conf
+++ b/greeter-osm.conf
@@ -12,15 +12,15 @@ statusfile = ./statusgreeter
 subject = Přivítání
 mainmessage = Ahoj <nick>,
 
-	děkujeme za tvůj první příspěvek do mapy OpenStreetMap. Zároveň si dovolujeme srdečně tě přivítat mezi komunitou nadšenců, kteří podobnými úpravami zlepšují či doplňují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí. Možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map - pak budeme rádi, když mu o OpenStreetMap řekneš. Způsobů, jakými je možné přispět, je mnoho - kromě samotného editování to může být například nahrávání GPS záznamů, nahlašování chyb nebo třeba propagace projektu.
+	děkujeme za tvůj první příspěvek do OpenStreetMap. Zároveň si dovolujeme srdečně tě přivítat mezi komunitu nadšenců, kteří podobnými úpravami doplňují či zlepšují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí, možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map - pak budeme rádi, když mu o OpenStreetMap řekneš. Způsobů, jakými je možné přispět, je mnoho - kromě samotného editování to může být například nahrávání GPS záznamů, nahlašování chyb nebo třeba propagace projektu.
 
-	Pokud se chceš na něco zeptat nebo se jenom podělit o své zkušenosti či nápad na zlepšení, tak tě rádi uvidíme na talk-cz@openstreetmap.org (https://lists.openstreetmap.org/listinfo/talk-cz?language=cs). Další informace o české komunitě: https://openstreetmap.cz/komunita 
-	A nezapomeň na zlaté pravidlo OpenStreetMap: bez výslovného povolení z cizích map (Google Mapy, Mapy.cz) nic nekopírujeme!
+	Pokud se chceš na něco zeptat nebo se jenom podělit o své zkušenosti či nápad na zlepšení, tak tě rádi potkáme v české konferenci talk-cz@openstreetmap.org (https://lists.openstreetmap.org/listinfo/talk-cz?language=cs). Další informace o české komunitě: https://openstreetmap.cz/komunita 
+	A nezapomeň na zlaté pravidlo OpenStreetMap: bez výslovného povolení z cizích map (Mapy Google, Mapy.cz) nic nekopírujeme!
 
 	Hodně štěstí,%%
-	tým České OpenStreetMap%%
+	tým české OpenStreetMap%%
 	openstreetmap.cz%%
 
-nosourcemessage=Všimli jsme si, že při ukládání změn jsi nepoužila(a) source tag. Ačkoliv je nepovinný, bývá dobrým zvykem ho použít. Na základě tohoto tagu je možné odvodit hodnověrnost dat a řešit konflikty s realitou při budoucích editacích. Více informací najdeš na: https://wiki.openstreetmap.org/wiki/Cs:Key:source
-nocommentmessage=Při uložení změn bývá dobrým zvykem přidávat komentář (v editoru iD: Krátký popis ukládaných změn, v JOSM: Krátký komentář k nahrávaným změnám), neboť ten umožní tobě i ostatním velmi rychle poznat o jaký typ úprav v rámci sady změn jde.
-ideditormessage=Zdá se, že jsi použil(a) editor iD. Pro občasné úpravy je výborný. Pokud ovšem plánuješ přispívat častěji, případně řešit komplikovanější záležitosti, tak jednoznačně doporučujeme pokročilejší editor JOSM (http://josm.openstreetmap.de), který má mnohem větší možnosti úprav, velké množství klávesových zkratek a rozšiřujících pluginů.
+nosourcemessage=Všimli jsme si, že při ukládání změn jsi nepoužil(a) značku "source". Ačkoliv je nepovinná, bývá dobrým zvykem ji použít. Na základě této značky je možné odvodit věrohodnost dat a řešit konflikty se skutečností v terénu při budoucích editacích. Více informací najdeš na: https://wiki.openstreetmap.org/wiki/Cs:Key:source
+nocommentmessage=Při uložení změn bývá dobrým zvykem přidávat komentář (v editoru iD: Krátký popis ukládaných změn, v editoru JOSM: Krátký komentář k nahrávaným změnám), neboť ten umožní tobě i ostatním velmi rychle poznat o jaký typ úprav v rámci sady změn jde.
+ideditormessage=Zdá se, že jsi použil(a) editor iD. Pro občasné úpravy je výborný. Pokud ovšem plánuješ přispívat častěji, případně řešit komplikovanější záležitosti, tak jednoznačně doporučujeme pokročilejší editor JOSM (http://josm.openstreetmap.de), který má mnohem větší možnosti úprav, velké množství klávesových zkratek a rozšiřujících doplňků.


### PR DESCRIPTION
- odebrání slova "mapa" z popisu OpenStreetMap – snažíme se lidem vysvětlit, že OSM není jen ta jedna mapa, kterou najdou na OSM.org. Zároveň, ten kdo začne přispívat, už nejspíš tuší, že OSM má něco společného s mapou, takže netřeba to zdůrazňovat
- opravy gramatiky
- plynulejší formulace
- vysvětlení toho, co to je talk-cz@openstreetmap.cz + změna slovesa ("uvidíme" by mohlo u neznalého nováčka vzbudit očekávání, že jde o komunikační nástroj zprostředkovávající i obraz)
- "tag" nahrazeno za "značka" - předpokládejme, že většina nováčků začne v editoru iD, kde jsou "tagy" právě takto přeloženy, takže je nechceme hned plést
- další počeštění (realita, plugin)