### PR TITLE
📝 Fix typos and improve text

### DIFF
--- a/greeter-osm.conf
+++ b/greeter-osm.conf
@@ -12,7 +12,7 @@ statusfile = ./statusgreeter
 subject = Přivítání
 mainmessage = Ahoj <nick>,
 
-	děkujeme za tvůj první příspěvek do OpenStreetMap. Zároveň si tě dovolujeme srdečně přivítat mezi komunitu nadšenců, kteří podobnými úpravami doplňují či zlepšují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí, možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map – pak budeme rádi, když mu o OpenStreetMap řekneš. Kromě samotného kreslení mapy lze pomáhat například nahráváním GPS záznamů, nahlašováním chyb nebo třeba propagací OpenStreetMap.
+	děkujeme za tvůj první příspěvek do OpenStreetMap. Zároveň si tě dovolujeme srdečně přivítat mezi komunitu nadšenců, kteří podobnými úpravami doplňují či zlepšují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí, možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map – pak budeme rádi, když mu o OpenStreetMap řekneš. Kromě samotného kreslení mapy lze pomáhat například nahráváním GPS záznamů, nahlašováním chyb, nebo třeba propagací OpenStreetMap.
 
 	Pokud se chceš na něco zeptat nebo se jenom podělit o své zkušenosti či nápad na zlepšení, rádi tě potkáme v české konferenci talk-cz@openstreetmap.org (https://lists.openstreetmap.org/listinfo/talk-cz?language=cs). Další informace o české komunitě: https://openstreetmap.cz/komunita 
 	A nezapomeň na zlaté pravidlo OpenStreetMap: bez výslovného povolení z cizích map (Mapy Google, Mapy.cz) nic nekopírujeme!

--- a/greeter-osm.conf
+++ b/greeter-osm.conf
@@ -12,15 +12,15 @@ statusfile = ./statusgreeter
 subject = Přivítání
 mainmessage = Ahoj <nick>,
 
-	děkujeme za tvůj první příspěvek do OpenStreetMap. Zároveň si dovolujeme srdečně tě přivítat mezi komunitu nadšenců, kteří podobnými úpravami doplňují či zlepšují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí, možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map - pak budeme rádi, když mu o OpenStreetMap řekneš. Způsobů, jakými je možné přispět, je mnoho - kromě samotného editování to může být například nahrávání GPS záznamů, nahlašování chyb nebo třeba propagace projektu.
+	děkujeme za tvůj první příspěvek do OpenStreetMap. Zároveň si tě dovolujeme srdečně přivítat mezi komunitu nadšenců, kteří podobnými úpravami doplňují či zlepšují mapu už několik let. Pokud je toto spíše jednorázová záležitost, nevadí, možná ve svém okolí znáš někoho, kdo rád chodí do lesa, jezdí na kole nebo je zkrátka nadšenec do map – pak budeme rádi, když mu o OpenStreetMap řekneš. Kromě samotného kreslení mapy lze pomáhat například nahráváním GPS záznamů, nahlašováním chyb nebo třeba propagací OpenStreetMap.
 
-	Pokud se chceš na něco zeptat nebo se jenom podělit o své zkušenosti či nápad na zlepšení, tak tě rádi potkáme v české konferenci talk-cz@openstreetmap.org (https://lists.openstreetmap.org/listinfo/talk-cz?language=cs). Další informace o české komunitě: https://openstreetmap.cz/komunita 
+	Pokud se chceš na něco zeptat nebo se jenom podělit o své zkušenosti či nápad na zlepšení, rádi tě potkáme v české konferenci talk-cz@openstreetmap.org (https://lists.openstreetmap.org/listinfo/talk-cz?language=cs). Další informace o české komunitě: https://openstreetmap.cz/komunita 
 	A nezapomeň na zlaté pravidlo OpenStreetMap: bez výslovného povolení z cizích map (Mapy Google, Mapy.cz) nic nekopírujeme!
 
 	Hodně štěstí,%%
 	tým české OpenStreetMap%%
 	openstreetmap.cz%%
 
-nosourcemessage=Všimli jsme si, že při ukládání změn jsi nepoužil(a) značku "source". Ačkoliv je nepovinná, bývá dobrým zvykem ji použít. Na základě této značky je možné odvodit věrohodnost dat a řešit konflikty se skutečností v terénu při budoucích editacích. Více informací najdeš na: https://wiki.openstreetmap.org/wiki/Cs:Key:source
-nocommentmessage=Při uložení změn bývá dobrým zvykem přidávat komentář (v editoru iD: Krátký popis ukládaných změn, v editoru JOSM: Krátký komentář k nahrávaným změnám), neboť ten umožní tobě i ostatním velmi rychle poznat o jaký typ úprav v rámci sady změn jde.
+nosourcemessage=Všimli jsme si, že při ukládání změn jsi nepoužil(a) značku „source“. Ačkoliv je nepovinná, bývá dobrým zvykem ji použít. Na základě této značky je možné odvodit věrohodnost dat a řešit konflikty se skutečností v terénu při budoucích editacích. Více informací najdeš na: https://wiki.openstreetmap.org/wiki/Cs:Key:source
+nocommentmessage=Při uložení změn bývá dobrým zvykem přidávat komentář – krátký popis ukládaných změn, neboť ten umožní tobě i ostatním velmi rychle poznat o jaký typ úprav v rámci sady změn jde.
 ideditormessage=Zdá se, že jsi použil(a) editor iD. Pro občasné úpravy je výborný. Pokud ovšem plánuješ přispívat častěji, případně řešit komplikovanější záležitosti, tak jednoznačně doporučujeme pokročilejší editor JOSM (http://josm.openstreetmap.de), který má mnohem větší možnosti úprav, velké množství klávesových zkratek a rozšiřujících doplňků.


### PR DESCRIPTION
Fix typos, rephrase and simplify certain sentences.

Explanation: In my opinion new user has no idea what's iD or JOSM (or whatever editor) so it's unnecessary to mention that. Important message is: there's something you should fill before commiting changes. I removed that part (it should also rise sustainability of the text).

Btw. this sentence:
`A nezapomeň na zlaté pravidlo OpenStreetMap: bez výslovného povolení z cizích map (Mapy Google, Mapy.cz) nic nekopírujeme!`
 – is it really so important and relevant for new user? If so, why not mention that he should map only objects existing in reality – that's IMO more important. Sometimes less is more…